### PR TITLE
YAML Update: add unkown for verify location

### DIFF
--- a/code/API_definitions/location.yaml
+++ b/code/API_definitions/location.yaml
@@ -182,8 +182,12 @@ components:
       maximum: 200
       example: 50
     VerificationResult:
-      description: Result of a verification request, true on match
-      type: boolean
+      description: Result of a verification request, true on match, false on unmatch and unknown on no result
+      type: string
+      enum:
+        - true
+        - false
+        - unknown
     ErrorInfo:
       type: object
       required:


### PR DESCRIPTION
Adding "unknown" #19
It can happen that the network can't locate the device, because it is offline and the location is also not cached. In this there should be coming the right response from the API. Changes
Adding to true or false the return value unkown, when it is not possible to get the location